### PR TITLE
fix: suppress hydration warnings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={inter.className}>
+    // Warning: Extra attributes from the server: cz-shortcut-listen
+    // https://stackoverflow.com/questions/75337953/what-causes-nextjs-warning-extra-attributes-from-the-server-data-new-gr-c-s-c
+    <html lang="en" suppressHydrationWarning>
+      <body className={inter.className} suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
Fix: Suppress hydration warnings 
Solution: https://stackoverflow.com/questions/75337953/what-causes-nextjs-warning-extra-attributes-from-the-server-data-new-gr-c-s-c